### PR TITLE
Amended documentation to correctly obtain logs

### DIFF
--- a/docs/20-spark-submit.md
+++ b/docs/20-spark-submit.md
@@ -28,5 +28,5 @@ aztk spark cluster submit --id spark --name pipy --no-wait examples/src/main/pyt
 ```
 
 ```sh
-aztk spark app logs --id spark --name pipy --tail
+aztk spark cluster app-logs --id spark --name pipy --tail
 ```


### PR DESCRIPTION
Documentation amended: Use of aztk spark app logs results in an error. Correct usage is aztk spark cluster app-logs. Document amended to reflect this.