### PR TITLE
Bug: fix alignment in get print cluster

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -43,8 +43,8 @@ def print_cluster(client, cluster: aztk.spark.models.Cluster):
     log.info("| Low priority: %s", __pretty_low_pri_node_count(cluster))
     log.info("")
 
-    print_format = '{:<36}| {:<15} | {:<21}| {:<8}'
-    print_format_underline = '{:-<36}|{:-<17}|{:-<22}|{:-<8}'
+    print_format = '{:<36}| {:<19} | {:<21}| {:<8}'
+    print_format_underline = '{:-<36}|{:-<21}|{:-<22}|{:-<8}'
     log.info(print_format.format("Nodes", "State", "IP:Port", "Master"))
     log.info(print_format_underline.format('', '', '', ''))
 


### PR DESCRIPTION
Fix #306 

This now looks like this:
```
Nodes                               | State               | IP:Port              | Master
------------------------------------|---------------------|----------------------|--------
tvm-3637016216_1-20180103t234355z   | waitingForStartTask | 13.67.129.164:50000  |
tvm-3637016216_2-20180103t234355z   | waitingForStartTask | 13.67.129.164:50001  |
```