### PR TITLE
Fix job list-apps crashes

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -332,6 +332,7 @@ def print_applications(applications):
                 print_format.format(
                     name,
                     "scheduling",
+                    "-",
                     "-"
                 )
             )
@@ -343,7 +344,7 @@ def print_applications(applications):
                     application.name,
                     application.state,
                     utc_to_local(application.state_transition_time),
-                    application.exit_code
+                    application.exit_code or "-"
                 )
             )
     if warn_scheduling:


### PR DESCRIPTION
I was just trying out the new job submission feature, and ran into a couple of crashes when running `aztk spark job list-apps`, stack traces below:

```
Traceback (most recent call last):
  File "/Users/emcorrin/.virtualenvs/aztk/bin/aztk", line 11, in <module>
    load_entry_point('aztk', 'console_scripts', 'aztk')()
  File "/Users/emcorrin/dev/analytics/aztk/cli/entrypoint.py", line 32, in main
    run_software(args)
  File "/Users/emcorrin/dev/analytics/aztk/cli/entrypoint.py", line 59, in run_software
    func(args)
  File "/Users/emcorrin/dev/analytics/aztk/cli/spark/endpoints/spark.py", line 31, in execute
    func(args)
  File "/Users/emcorrin/dev/analytics/aztk/cli/spark/endpoints/job/job.py", line 76, in execute
    func(args)
  File "/Users/emcorrin/dev/analytics/aztk/cli/spark/endpoints/job/list_apps.py", line 16, in execute
    utils.print_applications(spark_client.list_applications(args.job_id))
  File "/Users/emcorrin/dev/analytics/aztk/cli/utils.py", line 335, in print_applications
    "-"
IndexError: tuple index out of range
```

```
Traceback (most recent call last):
  File "/Users/emcorrin/.virtualenvs/aztk/bin/aztk", line 11, in <module>
    load_entry_point('aztk', 'console_scripts', 'aztk')()
  File "/Users/emcorrin/dev/analytics/aztk/cli/entrypoint.py", line 32, in main
    run_software(args)
  File "/Users/emcorrin/dev/analytics/aztk/cli/entrypoint.py", line 59, in run_software
    func(args)
  File "/Users/emcorrin/dev/analytics/aztk/cli/spark/endpoints/spark.py", line 31, in execute
    func(args)
  File "/Users/emcorrin/dev/analytics/aztk/cli/spark/endpoints/job/job.py", line 76, in execute
    func(args)
  File "/Users/emcorrin/dev/analytics/aztk/cli/spark/endpoints/job/list_apps.py", line 16, in execute
    utils.print_applications(spark_client.list_applications(args.job_id))
  File "/Users/emcorrin/dev/analytics/aztk/cli/utils.py", line 346, in print_applications
    application.exit_code
TypeError: unsupported format string passed to NoneType.__format__
```