### PR TITLE
Bug: move spark.local.dir to location usable by rstudioserver

### DIFF
--- a/config/spark-defaults.conf
+++ b/config/spark-defaults.conf
@@ -26,7 +26,7 @@
 # spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
 
 # set "scratch" space for Spark
-spark.local.dir                 /mnt/batch/
+spark.local.dir                 /mnt/batch/tasks
 
 # Note: Aztk pre-loads wasb jars, so loading is not necessary
 spark.jars                      /home/spark-current/jars/azure-storage-2.0.0.jar,/home/spark-current/jars/hadoop-azure-2.7.3.jar


### PR DESCRIPTION
Fix #403 