### PR TITLE
Fix job configuration option for `aztk spark job submit` command

### DIFF
--- a/aztk_cli/spark/endpoints/job/submit.py
+++ b/aztk_cli/spark/endpoints/job/submit.py
@@ -11,7 +11,7 @@ def setup_parser(parser: argparse.ArgumentParser):
                         dest='job_id',
                         required=False,
                         help='The unique id of your Spark Job. Defaults to the id value in .aztk/job.yaml')
-    parser.add_argument('--configuration' '-c',
+    parser.add_argument('--configuration', '-c',
                         dest='job_conf',
                         required=False,
                         help='Path to the job.yaml configuration file. Defaults to .aztk/job.yaml')

--- a/docs/70-jobs.md
+++ b/docs/70-jobs.md
@@ -92,7 +92,7 @@ Once submitted, this Job will run two applications, pipy100 and pipy200, on an a
 Submit a Spark Job:
 
 ```sh
-aztk spark job submit --id <your_job_id> --job-conf </path/to/job.yaml>
+aztk spark job submit --id <your_job_id> --configuration </path/to/job.yaml>
 ```
 
 NOTE: The Job id (`--id`) can only contain alphanumeric characters including hyphens and underscores, and cannot contain more than 64 characters. Each Job **must** have a unique id.


### PR DESCRIPTION
`--job-conf` option mentioned in the docs wasn't working.

CLI help was showing that option is named `--configuration-c`
which seems to be a result of a missing comma in option definition.