### PR TITLE
Feature: Support passing of remote executables via aztk spark cluster submit

### DIFF
--- a/aztk/node_scripts/submit.py
+++ b/aztk/node_scripts/submit.py
@@ -113,7 +113,9 @@ def __app_submit_cmd(
     if executor_cores:
         spark_submit_cmd.add_option('--executor-cores', str(executor_cores))
 
-    spark_submit_cmd.add_argument(app + ' ' + ' '.join(['\'' + str(app_arg) + '\'' for app_arg in (app_args or [])]))
+    spark_submit_cmd.add_argument(
+        os.path.expandvars(app) + ' ' + 
+        ' '.join(['\'' + str(app_arg) + '\'' for app_arg in (app_args or [])]))
 
     with open("spark-submit.txt", mode="w", encoding="UTF-8") as stream:
         stream.write(spark_submit_cmd.to_str())

--- a/aztk/node_scripts/submit.py
+++ b/aztk/node_scripts/submit.py
@@ -113,9 +113,7 @@ def __app_submit_cmd(
     if executor_cores:
         spark_submit_cmd.add_option('--executor-cores', str(executor_cores))
 
-    spark_submit_cmd.add_argument(
-        os.environ['AZ_BATCH_TASK_WORKING_DIR'] + '/' + app + ' ' +
-        ' '.join(['\'' + str(app_arg) + '\'' for app_arg in (app_args or [])]))
+    spark_submit_cmd.add_argument(app + ' ' + ' '.join(['\'' + str(app_arg) + '\'' for app_arg in (app_args or [])]))
 
     with open("spark-submit.txt", mode="w", encoding="UTF-8") as stream:
         stream.write(spark_submit_cmd.to_str())
@@ -156,7 +154,7 @@ def recieve_submit_request(application_file_path):
 
     cmd = __app_submit_cmd(
         name=application['name'],
-        app=os.path.basename(application['application']),
+        app=application['application'],
         app_args=application['application_args'],
         main_class=application['main_class'],
         jars=application['jars'],

--- a/aztk/spark/client.py
+++ b/aztk/spark/client.py
@@ -109,9 +109,9 @@ class Client(BaseClient):
         except batch_error.BatchErrorException as e:
             raise error.AztkError(helpers.format_batch_exception(e))
 
-    def submit(self, cluster_id: str, application: models.ApplicationConfiguration, skip_app_upload: bool = False, wait: bool = False):
+    def submit(self, cluster_id: str, application: models.ApplicationConfiguration, remote: bool = False, wait: bool = False):
         try:
-            cluster_submit_helper.submit_application(self, cluster_id, application, skip_app_upload, wait)
+            cluster_submit_helper.submit_application(self, cluster_id, application, remote, wait)
         except batch_error.BatchErrorException as e:
             raise error.AztkError(helpers.format_batch_exception(e))
 

--- a/aztk/spark/client.py
+++ b/aztk/spark/client.py
@@ -109,9 +109,9 @@ class Client(BaseClient):
         except batch_error.BatchErrorException as e:
             raise error.AztkError(helpers.format_batch_exception(e))
 
-    def submit(self, cluster_id: str, application: models.ApplicationConfiguration, wait: bool = False):
+    def submit(self, cluster_id: str, application: models.ApplicationConfiguration, skip_app_upload: bool = False, wait: bool = False):
         try:
-            cluster_submit_helper.submit_application(self, cluster_id, application, wait)
+            cluster_submit_helper.submit_application(self, cluster_id, application, skip_app_upload, wait)
         except batch_error.BatchErrorException as e:
             raise error.AztkError(helpers.format_batch_exception(e))
 

--- a/aztk/spark/helpers/submit.py
+++ b/aztk/spark/helpers/submit.py
@@ -17,10 +17,11 @@ def __get_node(spark_client, node_id: str, cluster_id: str) -> batch_models.Comp
     return spark_client.batch_client.compute_node.get(cluster_id, node_id)
 
 
-def generate_task(spark_client, container_id, application, skip_app_upload=False):
+def generate_task(spark_client, container_id, application, remote=False):
     resource_files = []
 
-    if not skip_app_upload:
+    # The application provided is not hosted remotely and therefore must be uploaded
+    if not remote:
         app_resource_file = helpers.upload_file_to_container(container_name=container_id,
                                                             application_name=application.name,
                                                             file_path=application.application,
@@ -114,11 +115,11 @@ def affinitize_task_to_master(spark_client, cluster_id, task):
     return task
 
 
-def submit_application(spark_client, cluster_id, application, skip_app_upload: bool = False, wait: bool = False):
+def submit_application(spark_client, cluster_id, application, remote: bool = False, wait: bool = False):
     """
     Submit a spark app
     """
-    task = generate_task(spark_client, cluster_id, application, skip_app_upload)
+    task = generate_task(spark_client, cluster_id, application, remote)
     task = affinitize_task_to_master(spark_client, cluster_id, task)
 
 

--- a/aztk/spark/helpers/submit.py
+++ b/aztk/spark/helpers/submit.py
@@ -17,17 +17,20 @@ def __get_node(spark_client, node_id: str, cluster_id: str) -> batch_models.Comp
     return spark_client.batch_client.compute_node.get(cluster_id, node_id)
 
 
-def generate_task(spark_client, container_id, application):
+def generate_task(spark_client, container_id, application, skip_app_upload=False):
     resource_files = []
 
-    app_resource_file = helpers.upload_file_to_container(container_name=container_id,
-                                                         application_name=application.name,
-                                                         file_path=application.application,
-                                                         blob_client=spark_client.blob_client,
-                                                         use_full_path=False)
+    if not skip_app_upload:
+        app_resource_file = helpers.upload_file_to_container(container_name=container_id,
+                                                            application_name=application.name,
+                                                            file_path=application.application,
+                                                            blob_client=spark_client.blob_client,
+                                                            use_full_path=False)
 
-    # Upload application file
-    resource_files.append(app_resource_file)
+        # Upload application file
+        resource_files.append(app_resource_file)
+
+        application.application = '$AZ_BATCH_TASK_WORKING_DIR/' + os.path.basename(application.application)
 
     # Upload dependent JARS
     jar_resource_file_paths = []
@@ -64,7 +67,6 @@ def generate_task(spark_client, container_id, application):
         resource_files.append(files_resource_file_path)
 
     # Upload application definition
-    application.application = os.path.basename(application.application)
     application.jars = [os.path.basename(jar) for jar in application.jars]
     application.py_files = [os.path.basename(py_files) for py_files in application.py_files]
     application.files = [os.path.basename(files) for files in application.files]
@@ -112,11 +114,11 @@ def affinitize_task_to_master(spark_client, cluster_id, task):
     return task
 
 
-def submit_application(spark_client, cluster_id, application, wait: bool = False):
+def submit_application(spark_client, cluster_id, application, skip_app_upload: bool = False, wait: bool = False):
     """
     Submit a spark app
     """
-    task = generate_task(spark_client, cluster_id, application)
+    task = generate_task(spark_client, cluster_id, application, skip_app_upload)
     task = affinitize_task_to_master(spark_client, cluster_id, task)
 
 

--- a/aztk_cli/spark/endpoints/cluster/cluster_submit.py
+++ b/aztk_cli/spark/endpoints/cluster/cluster_submit.py
@@ -70,18 +70,16 @@ def setup_parser(parser: argparse.ArgumentParser):
                         help='Path to the file you wish to output to. If not \
                               specified, output is printed to stdout')
 
-    parser.add_argument('--skip-app-upload', action='store_true',
-                        help='Do not upload app to cluster, assume it is already \
-                              accessible at the given path')
+    parser.add_argument('--remote', action='store_true',
+                        help='Do not upload the app to the cluster, assume it is \
+                              already accessible at the given path')
 
     parser.add_argument('app',
-                        help='App jar OR python file to execute. If the \
-                             --skip-app-upload flag is *not* set then an absolute \
-                             path to a local file should be used, the file will \
-                             then be uploaded to the storage account associated \
-                             with the cluster. If the --skip-app-upload is set \
-                             then the path provided need not be absolute but must \
-                             be accessible from within the docker container.')
+                        help='App jar OR python file to execute. A path to a local \
+                              file is expected, unless used in conjunction with \
+                              the --remote flag. When the --remote flag is set, a \
+                              remote path that is accessible from the cluster is \
+                              expected. Remote paths are not validated up-front.')
 
     parser.add_argument('app_args', nargs='*',
                         help='Arguments for the application')
@@ -155,7 +153,7 @@ def execute(args: typing.NamedTuple):
             executor_cores=args.executor_cores,
             max_retry_count=args.max_retry_count
         ),
-        skip_app_upload=args.skip_app_upload,
+        remote=args.remote,
         wait=False
     )
 

--- a/aztk_cli/spark/endpoints/cluster/cluster_submit.py
+++ b/aztk_cli/spark/endpoints/cluster/cluster_submit.py
@@ -70,9 +70,18 @@ def setup_parser(parser: argparse.ArgumentParser):
                         help='Path to the file you wish to output to. If not \
                               specified, output is printed to stdout')
 
+    parser.add_argument('--skip-app-upload', action='store_true',
+                        help='Do not upload app to cluster, assume it is already \
+                              accessible at the given path')
+
     parser.add_argument('app',
-                        help='App jar OR python file to execute. Use absolute \
-                              path to reference file.')
+                        help='App jar OR python file to execute. If the \
+                             --skip-app-upload flag is *not* set then an absolute \
+                             path to a local file should be used, the file will \
+                             then be uploaded to the storage account associated \
+                             with the cluster. If the --skip-app-upload is set \
+                             then the path provided need not be absolute but must \
+                             be accessible from within the docker container.')
 
     parser.add_argument('app_args', nargs='*',
                         help='Arguments for the application')
@@ -146,6 +155,7 @@ def execute(args: typing.NamedTuple):
             executor_cores=args.executor_cores,
             max_retry_count=args.max_retry_count
         ),
+        skip_app_upload=args.skip_app_upload,
         wait=False
     )
 

--- a/docs/20-spark-submit.md
+++ b/docs/20-spark-submit.md
@@ -9,9 +9,14 @@ Run a Spark job:
 aztk spark cluster submit --id <name_of_spark_cluster> --name <name_of_spark_job> <executable> <executable_params>
 ```
 
-For example, run a local pi.py file on a Spark cluster
+For example, to run a local pi.py file on a Spark cluster, simply specify the local path of the file:
 ```sh
 aztk spark cluster submit --id spark --name pipy examples/src/main/python/pi.py 100
+```
+
+To run a remotely hosted pi.py file on a Spark cluster, specify the remote path of the file and use the '--remote' flag:
+```sh
+aztk spark cluster submit --id spark --name pipy --remote wasbs://path@remote/pi.py 100
 ```
 
 NOTE: The job name (--name) must be atleast 3 characters long, can only contain alphanumeric characters including hyphens but excluding underscores, and cannot contain uppercase letters. Each job you submit **must** have a unique name.


### PR DESCRIPTION
fix #536

This change would allow the user to submit an app hosted at a remote location:

`aztk spark cluster submit [...] wasbs://path@remote/location.jar --skip-app-upload`

Or a location local to the docker container:

`aztk spark cluster submit [...] /local/to/docker_container.jar --skip-app-upload`

As well as supporting the current behaviour where the app is uploaded automatically

`aztk spark cluster submit [...] /local/absolute_path.jar`

The change involves moving the appending of "$AZ_BATCH_TASK_WORKING_DIR" to the application path to the client and only doing so if the "--skip-app-upload" flag is not set (note: the env variable is not resolved at this point since it is not known to the client). On the node, the now path is now un-altered.

Tested manually by:

* Submitting a job without the --skip-app-upload flag (current behaviour) :heavy_check_mark: 
* Submitting a job with the --skip-app-upload flag and using a wasb path to a remotely hosted jar :heavy_check_mark:
* Submitting a job with the --skip-app-upload flag and using a path to a jar that was copied to all nodes using `aztk spark cluster copy` :heavy_check_mark:

Seems like the integration tests are broken at the moment so haven't added any automated tests yet, happy to though if required.