### PR TITLE
Fix: VSTS build definition typo

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -23,7 +23,7 @@ phases:
       displayName: yapf
 
     - script: |
-        pylint -jobs 2 --errors-only aztk aztk_cli
+        pylint --jobs 2 --errors-only aztk aztk_cli
       condition: succeeded()
       displayName: pylint error check
     
@@ -38,7 +38,7 @@ phases:
       displayName: integration tests
     
     - script: |
-        pylint -jobs 2 --disable=fixme aztk aztk_cli
+        pylint --jobs 2 --disable=fixme aztk aztk_cli
       continueOnError: true
       condition: succeeded()
       displayName: pylint report


### PR DESCRIPTION
#651 introduced a typo into the vsts build definition causing false build fails