### PR TITLE
Include cluster creation time in output of cluster list and cluster get

### DIFF
--- a/aztk_cli/utils.py
+++ b/aztk_cli/utils.py
@@ -120,8 +120,9 @@ def print_clusters(clusters: List[models.Cluster]):
     for cluster in clusters:
         node_count = __pretty_node_count(cluster)
 
-        log.info(print_format.format(cluster.id, cluster.state.value, cluster.vm_size, node_count,
-                                     format_datetime(cluster.pool.creation_time, False)))
+        log.info(
+            print_format.format(cluster.id, cluster.state.value, cluster.vm_size, node_count,
+                                format_datetime(cluster.pool.creation_time, False)))
 
 
 def print_clusters_quiet(clusters: List[models.Cluster]):

--- a/aztk_cli/utils.py
+++ b/aztk_cli/utils.py
@@ -50,6 +50,7 @@ def print_cluster(client, cluster: models.Cluster, internal: bool = False):
     log.info("------------------------------------------")
     log.info("State:          %s", cluster.state.value)
     log.info("Node Size:      %s", cluster.vm_size)
+    log.info("Created:        %s", cluster.pool.creation_time.strftime('%Y-%m-%d %H:%M:%S'))
     log.info("Nodes:          %s", node_count)
     log.info("| Dedicated:    %s", __pretty_dedicated_node_count(cluster))
     log.info("| Low priority: %s", __pretty_low_pri_node_count(cluster))
@@ -106,15 +107,16 @@ def __pretty_low_pri_node_count(cluster: models.Cluster) -> str:
 
 
 def print_clusters(clusters: List[models.Cluster]):
-    print_format = "{:<34}| {:<10}| {:<20}| {:<7}"
-    print_format_underline = "{:-<34}|{:-<11}|{:-<21}|{:-<7}"
+    print_format = "{:<34}| {:<10}| {:<20}| {:<7}| {:<16}"
+    print_format_underline = "{:-<34}|{:-<11}|{:-<21}|{:-<8}|{:-<17}"
 
-    log.info(print_format.format("Cluster", "State", "VM Size", "Nodes"))
-    log.info(print_format_underline.format("", "", "", ""))
+    log.info(print_format.format("Cluster", "State", "VM Size", "Nodes", "Created"))
+    log.info(print_format_underline.format("", "", "", "", ""))
     for cluster in clusters:
         node_count = __pretty_node_count(cluster)
 
-        log.info(print_format.format(cluster.id, cluster.state.value, cluster.vm_size, node_count))
+        log.info(print_format.format(cluster.id, cluster.state.value, cluster.vm_size, node_count,
+                                     cluster.pool.creation_time.strftime('%Y-%m-%d %H:%M')))
 
 
 def print_clusters_quiet(clusters: List[models.Cluster]):

--- a/aztk_cli/utils.py
+++ b/aztk_cli/utils.py
@@ -42,6 +42,11 @@ def get_ssh_key_or_prompt(ssh_key, username, password, secrets_configuration):
     return ssh_key, password
 
 
+def format_datetime(datetime, include_seconds=True):
+    format = '%Y-%m-%d %H:%M' + (':%S' if include_seconds else '')
+    return datetime.strftime(format)
+
+
 def print_cluster(client, cluster: models.Cluster, internal: bool = False):
     node_count = __pretty_node_count(cluster)
 
@@ -50,7 +55,7 @@ def print_cluster(client, cluster: models.Cluster, internal: bool = False):
     log.info("------------------------------------------")
     log.info("State:          %s", cluster.state.value)
     log.info("Node Size:      %s", cluster.vm_size)
-    log.info("Created:        %s", cluster.pool.creation_time.strftime('%Y-%m-%d %H:%M:%S'))
+    log.info("Created:        %s", format_datetime(cluster.pool.creation_time))
     log.info("Nodes:          %s", node_count)
     log.info("| Dedicated:    %s", __pretty_dedicated_node_count(cluster))
     log.info("| Low priority: %s", __pretty_low_pri_node_count(cluster))
@@ -116,7 +121,7 @@ def print_clusters(clusters: List[models.Cluster]):
         node_count = __pretty_node_count(cluster)
 
         log.info(print_format.format(cluster.id, cluster.state.value, cluster.vm_size, node_count,
-                                     cluster.pool.creation_time.strftime('%Y-%m-%d %H:%M')))
+                                     format_datetime(cluster.pool.creation_time, False)))
 
 
 def print_clusters_quiet(clusters: List[models.Cluster]):


### PR DESCRIPTION
When listing clusters I find it's useful to have the creation time in order to differentiate between similar clusters (e.g. to shut down the older one), or to make it easier to spot clusters that have been unintentionally left running.

What do you think?