### PR TITLE
Clean up streaming log output

### DIFF
--- a/aztk_cli/utils.py
+++ b/aztk_cli/utils.py
@@ -134,7 +134,8 @@ def stream_logs(client, cluster_id, application_name):
     while True:
         app_logs = client.cluster.get_application_log(
             id=cluster_id, application_name=application_name, tail=True, current_bytes=current_bytes)
-        log.print(app_logs.log)
+        if app_logs.total_bytes > current_bytes:
+            print(app_logs.log, end='', flush=True)
         if app_logs.application_state == ApplicationState.Completed:
             return app_logs.exit_code
         current_bytes = app_logs.total_bytes


### PR DESCRIPTION
When streaming logs, some lines get prefixed with the local log info from aztk, while others don't, depending on whether they happen to be the first line of a batch from the remote machine. It also prints an empty log message every 3 seconds while no new logs are being generated.

I think it would be cleaner to just print the log stream without messing with it.

Or if you prefer to include the local log prefix, shouldn't the returned log messages be split into lines and logged individually so that the output is consistent?