### PR TITLE
Feature: Allow apps to use Batch task dependencies

### DIFF
--- a/aztk/client/cluster/helpers/create.py
+++ b/aztk/client/cluster/helpers/create.py
@@ -63,7 +63,11 @@ def create_pool_and_job_and_table(
     helpers.create_pool_if_not_exist(pool, core_cluster_operations.batch_client)
 
     # Create job
-    job = batch_models.JobAddParameter(id=job_id, pool_info=batch_models.PoolInformation(pool_id=pool_id))
+    job = batch_models.JobAddParameter(
+        id=job_id,
+        pool_info=batch_models.PoolInformation(pool_id=pool_id),
+        uses_task_depenendencies=True,
+    )
 
     # Add job to batch
     core_cluster_operations.batch_client.job.add(job)

--- a/aztk/spark/client/base/helpers/generate_application_task.py
+++ b/aztk/spark/client/base/helpers/generate_application_task.py
@@ -98,6 +98,7 @@ def generate_application_task(core_base_operations, container_id, application, r
         user_identity=batch_models.UserIdentity(
             auto_user=batch_models.AutoUserSpecification(
                 scope=batch_models.AutoUserScope.task, elevation_level=batch_models.ElevationLevel.admin)),
+        depends_on=application.depends_on,
     )
 
     return task

--- a/aztk/spark/models/models.py
+++ b/aztk/spark/models/models.py
@@ -135,6 +135,7 @@ class ApplicationConfiguration:
             driver_cores=None,
             executor_cores=None,
             max_retry_count=None,
+            depends_on=None,
     ):
         self.name = name
         self.application = application
@@ -151,6 +152,7 @@ class ApplicationConfiguration:
         self.driver_cores = driver_cores
         self.executor_cores = executor_cores
         self.max_retry_count = max_retry_count
+        self.depends_on = depends_on
 
 
 class ApplicationState(Enum):


### PR DESCRIPTION
Some of the Spark applications we have in the SwiftKey team require running different steps in a pipeline where each successive step relies on the previous step completing without failure. Azure Batch jobs have a mode that allows submitting tasks that depend on one or more other tasks, only running when those other tasks have completed successfully.

I am sure the AZTK team is already aware of task dependencies and probably either made a decision not to implement full support for app task dependencies or that it was not a priority. To properly add the concept of task dependencies to AZTK itself would probably entail a lot of extra functionality around app management.

However, for our purposes, just exposing the ability to express app dependencies with the underlying Batch task option `depends_on` is enough and we are happy to implement the specific app dependency management logic we need on our side.

This pull request, therefore, is a minimal set of changes that just adds the necessary parameters/arguments to cluster job and application task creation to enable use of task dependencies in Azure Batch.


Changes:
* Turn on `use_task_dependencies` option when creating the cluster job
* Add `depends_on` argument when generating an application task
* Add `depends_on` member to `spark.models.models.ApplicationConfiguration` and corresponding parameter to its `__init__()`