### PR TITLE
Fix: list_applications throwing error

### DIFF
--- a/aztk/spark/client/base/helpers/list_applications.py
+++ b/aztk/spark/client/base/helpers/list_applications.py
@@ -2,7 +2,7 @@ import azure.batch.models as batch_models
 from azure.batch.models import BatchErrorException
 
 from aztk import error
-from aztk.spark.models import SchedulingTarget
+from aztk.spark.models import Application, SchedulingTarget
 from aztk.utils import helpers
 
 
@@ -10,9 +10,9 @@ def list_applications(core_operations, cluster_id):
     try:
         scheduling_target = core_operations.get_cluster_configuration(cluster_id).scheduling_target
         if scheduling_target is not SchedulingTarget.Any:
-            task = core_operations.list_task_table_entries(cluster_id)
+            tasks = core_operations.list_task_table_entries(cluster_id)
         else:
-            task = core_operations.list_batch_tasks(cluster_id)
-        return task
+            tasks = core_operations.list_batch_tasks(cluster_id)
+        return [Application(task) for task in tasks]
     except BatchErrorException as e:
         raise error.AztkError(helpers.format_batch_exception(e))

--- a/aztk/spark/client/base/helpers/list_applications.py
+++ b/aztk/spark/client/base/helpers/list_applications.py
@@ -2,22 +2,17 @@ import azure.batch.models as batch_models
 from azure.batch.models import BatchErrorException
 
 from aztk import error
-from aztk.spark import models
+from aztk.spark.models import SchedulingTarget
 from aztk.utils import helpers
 
 
-def _list_applications(core_operations, id):
-    # info about the app
-    scheduling_target = core_operations.get_cluster_configuration(id).scheduling_target
-    if scheduling_target is not models.SchedulingTarget.Any:
-        return models.Application(core_operations.list_applications(id))
-
-    recent_run_job = core_operations.get_recent_job(id)
-    return core_operations.list_batch_tasks(id=recent_run_job.id)
-
-
-def list_applications(core_operations, id):
+def list_applications(core_operations, cluster_id):
     try:
-        return models.Application(_list_applications(core_operations, id))
+        scheduling_target = core_operations.get_cluster_configuration(cluster_id).scheduling_target
+        if scheduling_target is not SchedulingTarget.Any:
+            task = core_operations.list_task_table_entries(cluster_id)
+        else:
+            task = core_operations.list_batch_tasks(cluster_id)
+        return task
     except BatchErrorException as e:
         raise error.AztkError(helpers.format_batch_exception(e))

--- a/aztk/spark/client/base/operations.py
+++ b/aztk/spark/client/base/operations.py
@@ -79,6 +79,6 @@ class SparkBaseOperations:
             id (:obj:`str`): the name of the cluster the tasks belong to
 
         Returns:
-            :obj:`[aztk.models.Task]`: list of aztk tasks
+            :obj:`[aztk.spark.models.Application]`: list of aztk applications
         """
         return list_applications.list_applications(core_base_operations, id)

--- a/aztk/spark/client/base/operations.py
+++ b/aztk/spark/client/base/operations.py
@@ -72,7 +72,7 @@ class SparkBaseOperations:
         return generate_application_task.generate_application_task(core_base_operations, container_id, application,
                                                                    remote)
 
-    def list_applications(self, id):
+    def _list_applications(self, core_base_operations, id):
         """Get information on a submitted application
 
         Args:
@@ -82,4 +82,4 @@ class SparkBaseOperations:
         Returns:
             :obj:`aztk.spark.models.Application`: object representing that state and output of an application
         """
-        return list_applications.list_applications(self, id)
+        return list_applications.list_applications(core_base_operations, id)

--- a/aztk/spark/client/base/operations.py
+++ b/aztk/spark/client/base/operations.py
@@ -73,13 +73,12 @@ class SparkBaseOperations:
                                                                    remote)
 
     def _list_applications(self, core_base_operations, id):
-        """Get information on a submitted application
+        """Get information on tasks submitted to a cluster
 
         Args:
-            id (:obj:`str`): the name of the job the application was submitted to
-            application_name (:obj:`str`): the name of the application to get
+            id (:obj:`str`): the name of the cluster the tasks belong to
 
         Returns:
-            :obj:`aztk.spark.models.Application`: object representing that state and output of an application
+            :obj:`[aztk.models.Task]`: list of aztk tasks
         """
         return list_applications.list_applications(core_base_operations, id)

--- a/aztk/spark/client/cluster/operations.py
+++ b/aztk/spark/client/cluster/operations.py
@@ -117,6 +117,17 @@ class ClusterOperations(SparkBaseOperations):
         """
         return get_application_state.get_application_state(self._core_cluster_operations, id, application_name)
 
+    def list_applications(self, id: str):
+        """Get all tasks that have been submitted to the cluster
+
+        Args:
+            id (:obj:`str`): the name of the cluster the tasks belong to
+
+        Returns:
+            :obj:`[aztk.models.Task]`: list of aztk tasks
+        """
+        return self._list_applications(self._core_cluster_operations, id)
+
     def run(self, id: str, command: str, host=False, internal: bool = False, timeout=None):
         """Run a bash command on every node in the cluster
 

--- a/aztk/spark/client/cluster/operations.py
+++ b/aztk/spark/client/cluster/operations.py
@@ -124,7 +124,7 @@ class ClusterOperations(SparkBaseOperations):
             id (:obj:`str`): the name of the cluster the tasks belong to
 
         Returns:
-            :obj:`[aztk.models.Task]`: list of aztk tasks
+            :obj:`[aztk.spark.models.Application]`: list of aztk applications
         """
         return self._list_applications(self._core_cluster_operations, id)
 


### PR DESCRIPTION
list_applications was previously throwing this error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...\aztk\spark\client\base\operations.py", line 85, in list_applications
    return list_applications.list_applications(self, id)
  File "...\aztk\spark\client\base\helpers\list_applications.py", line 21, in list_applications
    return models.Application(_list_applications(core_operations, id))
  File "...\aztk\spark\client\base\helpers\list_applications.py", line 11, in _list_applications
    scheduling_target = core_operations.get_cluster_configuration(id).scheduling_target
AttributeError: 'ClusterOperations' object has no attribute 'get_cluster_configuration'
```

It is now working and returns a list of tasks.